### PR TITLE
Use system wide ssh agent as a default with SFTP

### DIFF
--- a/src/fs/sftp.ts
+++ b/src/fs/sftp.ts
@@ -449,8 +449,9 @@ export class SFTPFileSystem extends vscrw_fs.FileSystemBase {
             }
 
             const OPTS: any = {
-                agent: vscode_helpers.isEmptyString(agent) ? undefined
-                                                           : agent,
+                agent: vscode_helpers.isEmptyString(agent)
+                    ? (process.platform === 'win32' ? 'pageant' : process.env.SSH_AUTH_SOCK)
+                    : agent,
                 agentForward: vscrw.isTrue(agentForward),
                 host: HOST_AND_CRED.host,
                 hostHash: <any>('' === hostHash ? 'md5' : hostHash),


### PR DESCRIPTION
Unless the agent option is explicitly defined in a workspace configuration there is no reason not to use the system ssh agent by default.
IMHO this is the expected behaviour and matches what happens when I try to connect to any server using openssh.
No need for complicated variable replacements in every single workspace configuration file.

I've been applying this change in my local installation since I discovered this extension and it works really well.

Thanks!